### PR TITLE
Fix a bug where the second map was not correctly initialized

### DIFF
--- a/js/nwm-gmap3.js
+++ b/js/nwm-gmap3.js
@@ -1,7 +1,9 @@
 jQuery( document ).ready( function( $ ) {
 
-if ( $( "#nwm-map-0" ).length ) {
-	$( ".nwm-wrap" ).eq(0).parent().wrap( "<div id='nwm-outer'>", "</div>" );
+var count = 0 ;
+while ( $( "#nwm-map-"+count ).length ) {
+	$( ".nwm-wrap" ).eq(count).parent().wrap( "<div id='nwm-outer'>", "</div>" );
+	count ++;
 }
 
 var flightPath = [],


### PR DESCRIPTION
Might not be the cleanest fix but it works for me. I had a peculiar case where with one map in a sidebar widget, the same map could not load in the page or article. Up to you to integrate or not. I did not do extensive testing, only working for my use case.