### PR TITLE
Fix PHP 8.0+ compatibility issues

### DIFF
--- a/admin/nwm-check-upgrade.php
+++ b/admin/nwm-check-upgrade.php
@@ -17,10 +17,10 @@ function nwm_version_updates()
 
     $current_version = get_option('nwm_version');
 
-    if (version_compare($current_version, NWN_VERSION_NUM, '==='))
+    if (version_compare($current_version ?: '0', NWN_VERSION_NUM, '=='))
         return;
 
-    if (version_compare($current_version, '1.0.3', '<')) {
+    if (version_compare($current_version ?: '0', '1.0.3', '<')) {
         $settings = get_option('nwm_settings');
 
         if (is_array($settings) && empty($settings['zoom_level'])) {
@@ -30,7 +30,7 @@ function nwm_version_updates()
         }
     }
 
-    if (version_compare($current_version, '1.1', '<')) {
+    if (version_compare($current_version ?: '0', '1.1', '<')) {
 
         /* Add the thumb_id field to the table */
         $sql = "CREATE TABLE " . $wpdb->nwm_routes . " (
@@ -103,7 +103,7 @@ function nwm_version_updates()
         nwm_delete_all_transients();
     }
 
-    if (version_compare($current_version, '1.1.4', '<')) {
+    if (version_compare($current_version ?: '0', '1.1.4', '<')) {
         $settings = get_option('nwm_settings');
 
         if (is_array($settings)) {
@@ -129,7 +129,7 @@ function nwm_version_updates()
         nwm_delete_all_transients();
     }
 
-    if (version_compare($current_version, '1.2', '<')) {
+    if (version_compare($current_version ?: '0', '1.2', '<')) {
 
         /* Add the country_code field to the table */
         $sql = "CREATE TABLE " . $wpdb->nwm_routes . " (
@@ -169,11 +169,11 @@ function nwm_version_updates()
 
     }
 
-    if (version_compare($current_version, '1.2.21', '<')) {
+    if (version_compare($current_version ?: '0', '1.2.21', '<')) {
         nwm_delete_all_transients();
     }
 
-    if (version_compare($current_version, '1.2.30', '<')) {
+    if (version_compare($current_version ?: '0', '1.2.30', '<')) {
         $settings = get_option('nwm_settings');
 
         if (is_array($settings)) {

--- a/admin/nwm-install.php
+++ b/admin/nwm-install.php
@@ -24,7 +24,10 @@ function nwm_default_settings()
             'content_location' => 'slider',
             'location_header' => '0',
             'read_more_label' => 'Read more',
-            'latlng_input' => '0'
+            'latlng_input' => '0',
+            'initial_tooltip' => '0',
+            'google_api_browser_key' => '',
+            'google_api_server_key' => ''
         );
 
         update_option('nwm_settings', $settings);

--- a/includes/nwm-frontend-functions.php
+++ b/includes/nwm-frontend-functions.php
@@ -489,7 +489,7 @@ function nwm_frontend_scripts( $frontend_data, $map_count ) {
              'readMore' 	   => $frontend_data['settings']['read_more'],
              'readMoreLabel'   => sanitize_text_field( stripslashes( $frontend_data['settings']['read_more_label'] ) ),
              'locationHeader'  => $frontend_data['settings']['location_header'],
-             'hideTooltip'  => $frontend_data['settings']['initial_tooltip']
+             'hideTooltip'  => isset($frontend_data['settings']['initial_tooltip']) ? $frontend_data['settings']['initial_tooltip'] : 0
          );
 
          wp_localize_script( 'nwm-gmap-markers', 'nwmSettings', $params );

--- a/includes/nwm-widget-class.php
+++ b/includes/nwm-widget-class.php
@@ -323,7 +323,7 @@ class NWM_Widget extends WP_Widget {
     }
 }
 
-add_action( 'widgets_init',
-     create_function( '', 'return register_widget( "NWM_Widget" );' )
-);
+add_action( 'widgets_init', function() {
+    register_widget( 'NWM_Widget' );
+});
 


### PR DESCRIPTION
## Summary

This PR fixes several compatibility issues that prevent the plugin from working on PHP 8.0+:

- **Replace deprecated `create_function()`** - The `create_function()` function was removed in PHP 8.0. Replaced with anonymous function in widget registration (`includes/nwm-widget-class.php`)

- **Fix `version_compare()` invalid operator** - The `===` operator is not valid for `version_compare()`. Changed to `==` (`admin/nwm-check-upgrade.php`)

- **Handle empty version string** - `version_compare()` throws a ValueError when passed an empty string on PHP 8. Added null coalescing to default to `'0'` when `$current_version` is empty

- **Add missing default settings** - Added `initial_tooltip`, `google_api_browser_key`, and `google_api_server_key` to prevent undefined index errors (`admin/nwm-install.php`)

- **Add defensive isset() check** - Added check for `initial_tooltip` setting before access (`includes/nwm-frontend-functions.php`)

## Test plan

- [x] Tested plugin activation on PHP 8.2
- [x] Verified plugin loads without fatal errors
- [x] Confirmed map renders with existing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)